### PR TITLE
use stdClass instead of array for term definition sets

### DIFF
--- a/src/Yitznewton/Procslyte/Render/Text/TermRenderer.php
+++ b/src/Yitznewton/Procslyte/Render/Text/TermRenderer.php
@@ -13,16 +13,18 @@ class TermRenderer implements Renderer
 
     /**
      * @param array $termName
-     * @param array $allTermDefinitions
+     * @param \stdClass $allTermDefinitions  use \stdClass because pass-by-reference;
+     *                                       this way, many TermRenderers can share
+     *                                       the same object
      * @param array $options
      */
-    public function __construct($termName, array $allTermDefinitions, array $options = [])
+    public function __construct($termName, \stdClass $allTermDefinitions, array $options = [])
     {
-        $this->termDefinitions = $this->in($allTermDefinitions, [$termName]);
-
-        if (!$this->termDefinitions) {
+        if (!isset($allTermDefinitions->$termName)) {
             throw new UndefinedIndexException();
         }
+
+        $this->termDefinitions = $allTermDefinitions->$termName;
 
         $this->options = $options;
     }

--- a/tests/Yitznewton/Tests/Procslyte/Render/TermRendererTest.php
+++ b/tests/Yitznewton/Tests/Procslyte/Render/TermRendererTest.php
@@ -11,7 +11,7 @@ class TermRendererTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->termSet = [
+        $this->termSet = (object) [
             'foo' => [
                 [
                     'form' => 'long',
@@ -29,14 +29,14 @@ class TermRendererTest extends \PHPUnit_Framework_TestCase
     public function testWithMissingTerm()
     {
         $this->setExpectedException('\\Yitznewton\\Procslyte\\UndefinedIndexException');
-        $termSet = [];
+        $termSet = new \stdClass();
         new TermRenderer('foo', $termSet);
     }
 
     public function testWithMissingValue()
     {
         $this->setExpectedException('\\Yitznewton\\Procslyte\\InvalidTermException');
-        $termSet = ['foo' => [['bar' => 'baz']]];
+        $termSet = (object) ['foo' => [['bar' => 'baz']]];
         $renderer = new TermRenderer('foo', $termSet);
         $renderer->render([]);
     }


### PR DESCRIPTION
Use `\stdClass` because pass-by-reference; this way, many `TermRenderer`s can share the same object
